### PR TITLE
Remove the outer ptrMath template

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,23 +23,22 @@ for i, _ in a:
   a[i] += i
 echo &"before                    : a = {a}"
 
-ptrMath:
-  p += 1                  # p is now pointing to a[1]
-  p[] = 100               # p[] is accessing the contents of a[1]
-  echo &"after p += 1; p[] = 100   : a = {a}"
+p += 1                  # p is now pointing to a[1]
+p[] = 100               # p[] is accessing the contents of a[1]
+echo &"after p += 1; p[] = 100   : a = {a}"
 
-  p[0] = 200              # .. so does p[0]
-  echo &"after p[0] = 200          : a = {a}"
+p[0] = 200              # .. so does p[0]
+echo &"after p[0] = 200          : a = {a}"
 
-  p[1] -= 2               # p[1] is accessing the contents of a[2]
-  echo &"after p[1] -= 2           : a = {a}"
+p[1] -= 2               # p[1] is accessing the contents of a[2]
+echo &"after p[1] -= 2           : a = {a}"
 
-  p[2] += 50              # p[2] is accessing the contents of a[3]
-  echo &"after p[2] += 50          : a = {a}"
+p[2] += 50              # p[2] is accessing the contents of a[3]
+echo &"after p[2] += 50          : a = {a}"
 
-  p += 2                  # p is now pointing to a[3]
-  p[-1] += 77             # p[-1] is accessing the contents of a[2]
-  echo &"after p += 2; p[-1] += 77 : a = {a}"
+p += 2                  # p is now pointing to a[3]
+p[-1] += 77             # p[-1] is accessing the contents of a[2]
+echo &"after p += 2; p[-1] += 77 : a = {a}"
 
 echo &"a[0] = p[-3] = {p[-3]}"
 echo &"a[1] = p[-2] = {p[-2]}"

--- a/config.nims
+++ b/config.nims
@@ -2,9 +2,3 @@ task pullConfig, "Fetch my global config.nims":
   exec("git submodule add -f -b master https://github.com/kaushalmodi/nim_config")
 when fileExists("nim_config/config.nims"):
   include "nim_config/config.nims" # This gives "nim test" and "nim docs" that's run on Travis
-
-when getCommand() == "doc":
-  # https://github.com/nim-lang/Nim/issues/18157#issuecomment-853317509
-  # Export the documentation of the unexported internal templates
-  # defined inside ptrMath as well.
-  switch("docInternal", "on")

--- a/src/ptr_math.nim
+++ b/src/ptr_math.nim
@@ -10,167 +10,175 @@
 ## `Repo link <https://github.com/kaushalmodi/ptr_math>`_
 ##
 ## The code in this module is mostly from `this code snippet <https://forum.nim-lang.org/t/1188#7366>`_ on Nim Forum.
+runnableExamples:
+  var
+    a: array[0 .. 3, int]
+    p = addr(a[0])        # p is pointing to a[0]
 
-template ptrMath*(body: untyped) =
-  ## Enclosure to contain the pointer arithmetic expressions.
+  for i, _ in a:
+    a[i] += i
+
+  p += 1                  # p is now pointing to a[1]
+  p[] = 100               # p[] is accessing the contents of a[1]
+  doAssert a[1] == 100
+
+  p[0] = 200              # .. so does p[0]
+  doAssert a[1] == 200
+
+  p[1] -= 2               # p[1] is accessing the contents of a[2]
+  doAssert a[2] == 0
+
+  p[2] += 50              # p[2] is accessing the contents of a[3]
+  doAssert a[3] == 53
+
+  p += 2                  # p is now pointing to a[3]
+  p[-1] += 77             # p[-1] is accessing the contents of a[2]
+  doAssert a[2] == 77
+
+  doAssert a == [0, 200, 77, 53]
+##
+
+template `+`*[T](p: ptr T, offset: int): ptr T =
+  ## Increments pointer `p` by `offset` that jumps memory in increments of
+  ## the size of `T`.
+  runnableExamples:
+    type
+      MyObject = object
+        i: int
+        f: float
+        b: bool
+    var
+      a = [MyObject(i: 100, f: 2.3, b: true),
+           MyObject(i: 300, f: 4.5, b: false),
+           MyObject(i: 500, f: 6.7, b: true)]
+      p = addr(a[0])
+      p2 = p + 2
+
+    doAssert p2[0].i == 500
+    doAssert p2[-1].f == 4.5
+  ##
+  cast[ptr T](cast[ByteAddress](p) +% (offset * sizeof(T)))
+  #                               `+%` treats x and y inputs as unsigned
+  # and adds them: https://nim-lang.github.io/Nim/system.html#%2B%25%2Cint%2Cint
+
+template `-`*[T](p: ptr T, offset: int): ptr T =
+  ## Decrements pointer `p` by `offset` that jumps memory in increments of
+  ## the size of `T`.
+  runnableExamples:
+    type
+      MyObject = object
+        i: int
+        f: float
+        b: bool
+    var
+      a = [MyObject(i: 100, f: 2.3, b: true),
+           MyObject(i: 300, f: 4.5, b: false),
+           MyObject(i: 500, f: 6.7, b: true)]
+      p = addr(a[2])
+      p1 = p - 1
+    doAssert p1[0].i == 300
+    doAssert p1[-1].b == true
+    doAssert p1[1].f == 6.7
+  ##
+  cast[ptr T](cast[ByteAddress](p) -% (offset * sizeof(T)))
+
+template `[]`*[T](p: ptr T, offset: int): T =
+  ## Retrieves the value from `p[offset]`.
   runnableExamples:
     var
-      a: array[0 .. 3, int]
-      p = addr(a[0])        # p is pointing to a[0]
+      a = [1, 3, 5, 7]
+      p = addr(a[0])
 
-    for i, _ in a:
-      a[i] += i
-
-    ptrMath:
-      p += 1                  # p is now pointing to a[1]
-      p[] = 100               # p[] is accessing the contents of a[1]
-      doAssert a[1] == 100
-
-      p[0] = 200              # .. so does p[0]
-      doAssert a[1] == 200
-
-      p[1] -= 2               # p[1] is accessing the contents of a[2]
-      doAssert a[2] == 0
-
-      p[2] += 50              # p[2] is accessing the contents of a[3]
-      doAssert a[3] == 53
-
-      p += 2                  # p is now pointing to a[3]
-      p[-1] += 77             # p[-1] is accessing the contents of a[2]
-      doAssert a[2] == 77
-    doAssert a == [0, 200, 77, 53]
+    doAssert p[] == a[0]
+    doAssert p[0] == a[0]
+    doAssert p[2] == a[2]
   ##
-  template `+`[T](p: ptr T, offset: int): ptr T {.used.} =
-    ## Increments pointer `p` by `offset` that jumps memory in increments of
-    ## the size of `T`.
-    ## This can be used only within the `ptrMath:` template.
-    runnableExamples:
-      type
-        MyObject = object
-          i: int
-          f: float
-          b: bool
-      var
-        a = [MyObject(i: 100, f: 2.3, b: true),
-             MyObject(i: 300, f: 4.5, b: false),
-             MyObject(i: 500, f: 6.7, b: true)]
-        p = addr(a[0])
+  (p + offset)[]
 
-      ptrMath:
-        var
-          p2 = p + 2
-        doAssert p2[0].i == 500
-        doAssert p2[-1].f == 4.5
-    ##
-    cast[ptr T](cast[ByteAddress](p) +% (offset * sizeof(T)))
-    #                               `+%` treats x and y inputs as unsigned
-    # and adds them: https://nim-lang.github.io/Nim/system.html#%2B%25%2Cint%2Cint
+template `[]=`*[T](p: ptr T, offset: int, val: T) =
+  ## Assigns the value at memory location pointed by `p[offset]`.
+  runnableExamples:
+    var
+      a = [1.3, -9.5, 100.0]
+      p = addr(a[1])
 
-  template `-`[T](p: ptr T, offset: int): ptr T {.used.} =
-    ## Decrements pointer `p` by `offset` that jumps memory in increments of
-    ## the size of `T`.
-    ## This can be used only within the `ptrMath:` template.
-    runnableExamples:
-      type
-        MyObject = object
-          i: int
-          f: float
-          b: bool
-      var
-        a = [MyObject(i: 100, f: 2.3, b: true),
-             MyObject(i: 300, f: 4.5, b: false),
-             MyObject(i: 500, f: 6.7, b: true)]
-        p = addr(a[2])
+    p[0] = 123.456
+    doAssert a[1] == 123.456
+  ##
+  (p + offset)[] = val
 
-      ptrMath:
-        var
-          p1 = p - 1
-        doAssert p1[0].i == 300
-        doAssert p1[-1].b == true
-        doAssert p1[1].f == 6.7
-    ##
-    cast[ptr T](cast[ByteAddress](p) -% (offset * sizeof(T)))
+template `+=`*[T](p: ptr T, offset: int) =
+  ## Increments pointer `p` *in place* by `offset` that jumps memory
+  ## in increments of the size of `T`.
+  runnableExamples:
+    type
+      MyObject = object
+        i: int
+        f: float
+        b: bool
+    var
+      a = [MyObject(i: 100, f: 2.3, b: true),
+           MyObject(i: 300, f: 4.5, b: false),
+           MyObject(i: 500, f: 6.7, b: true)]
+      p = addr(a[0])
 
-  template `[]`[T](p: ptr T, offset: int): T {.used.} =
-    ## Retrieves the value from `p[offset]`.
-    ## This can be used only within the `ptrMath:` template.
-    runnableExamples:
-      var
-        a = [1, 3, 5, 7]
-        p = addr(a[0])
+    p += 1
+    doAssert p[].i == 300
+  ##
+  p = p + offset
 
-      ptrMath:
-        doAssert p[] == a[0]
-        doAssert p[0] == a[0]
-        doAssert p[2] == a[2]
-    ##
-    (p + offset)[]
+template `-=`*[T](p: ptr T, offset: int) =
+  ## Decrements pointer `p` *in place* by `offset` that jumps memory
+  ## in increments of the size of `T`.
+  runnableExamples:
+    type
+      MyObject = object
+        i: int
+        f: float
+        b: bool
+    var
+      a = [MyObject(i: 100, f: 2.3, b: true),
+           MyObject(i: 300, f: 4.5, b: false),
+           MyObject(i: 500, f: 6.7, b: true)]
+      p = addr(a[2])
 
-  template `[]=`[T](p: ptr T, offset: int, val: T) {.used.} =
-    ## Assigns the value at memory location pointed by `p[offset]`.
-    ## This can be used only within the `ptrMath:` template.
-    runnableExamples:
-      var
-        a = [1.3, -9.5, 100.0]
-        p = addr(a[1])
-
-      ptrMath:
-        p[0] = 123.456
-        doAssert a[1] == 123.456
-    ##
-    (p + offset)[] = val
-
-  template `+=`[T](p: ptr T, offset: int) {.used.} =
-    ## Increments pointer `p` *in place* by `offset` that jumps memory
-    ## in increments of the size of `T`.
-    ## This can be used only within the `ptrMath:` template.
-    runnableExamples:
-      type
-        MyObject = object
-          i: int
-          f: float
-          b: bool
-      var
-        a = [MyObject(i: 100, f: 2.3, b: true),
-             MyObject(i: 300, f: 4.5, b: false),
-             MyObject(i: 500, f: 6.7, b: true)]
-        p = addr(a[0])
-
-      ptrMath:
-        p += 1
-        doAssert p[].i == 300
-    ##
-    p = p + offset
-
-  template `-=`[T](p: ptr T, offset: int) {.used.} =
-    ## Decrements pointer `p` *in place* by `offset` that jumps memory
-    ## in increments of the size of `T`.
-    ## This can be used only within the `ptrMath:` template.
-    runnableExamples:
-      type
-        MyObject = object
-          i: int
-          f: float
-          b: bool
-      var
-        a = [MyObject(i: 100, f: 2.3, b: true),
-             MyObject(i: 300, f: 4.5, b: false),
-             MyObject(i: 500, f: 6.7, b: true)]
-        p = addr(a[2])
-
-      ptrMath:
-        p -= 2
-        doAssert p[].f == 2.3
-    ##
-    p = p - offset
-
-  body
+    p -= 2
+    doAssert p[].f == 2.3
+  ##
+  p = p - offset
 
 
 when isMainModule:
+  import std/[strformat]
 
-  # https://github.com/nim-lang/Nim/issues/18157#issuecomment-853323724
-  # Below call to `ptrMath` is needed so that the inner templates get
-  # generated and picked up by docgen.
-  ptrMath:
-    discard
+  var
+    a: array[0 .. 3, int]
+    p = addr(a[0])                                # p is pointing to a[0]
+
+  for i, _ in a:
+    a[i] += i
+  echo &"before                    : a = {a}"
+
+  p += 1                                          # p is now pointing to a[1]
+  p[] = 100                                       # p[] is accessing the contents of a[1]
+  echo &"after p += 1; p[] = 100   : a = {a}"
+
+  p[0] = 200                                      # .. so does p[0]
+  echo &"after p[0] = 200          : a = {a}"
+
+  p[1] -= 2                                       # p[1] is accessing the contents of a[2]
+  echo &"after p[1] -= 2           : a = {a}"
+
+  p[2] += 50                                      # p[2] is accessing the contents of a[3]
+  echo &"after p[2] += 50          : a = {a}"
+
+  p += 2                                          # p is now pointing to a[3]
+  p[-1] += 77                                     # p[-1] is accessing the contents of a[2]
+  echo &"after p += 2; p[-1] += 77 : a = {a}"
+
+  echo &"a[0] = p[-3] = {p[-3]}"
+  echo &"a[1] = p[-2] = {p[-2]}"
+  echo &"a[2] = p[-1] = {p[-1]}"
+  echo &"a[3] = p[0] = {p[0]}"
+
+  doAssert a == [0, 200, 77, 53]

--- a/tests/tbasic.nim
+++ b/tests/tbasic.nim
@@ -16,41 +16,35 @@ suite "basic":
       p = addr(a[0])
 
   test "incr ptr":
-    ptrMath:
-      p = p + 1
-      check p[0].i == 300
+    p = p + 1
+    check p[0].i == 300
 
   test "decr ptr":
-    ptrMath:
-      p = addr(a[2])
-      p = p - 1
-      check p[0].f == 4.5
+    p = addr(a[2])
+    p = p - 1
+    check p[0].f == 4.5
 
   test "retrieve value `[]`":
-    ptrMath:
-      p = addr(a[1])
-      check p[0] == a[1]
-      check p[1] == a[2]
-      check p[-1] == a[0]
+    p = addr(a[1])
+    check p[0] == a[1]
+    check p[1] == a[2]
+    check p[-1] == a[0]
 
   test "assign value `[]=`":
-    ptrMath:
-      p[1].f = 123.456
-      check a[1].f == 123.456
-      p[2] = MyObject(i: 11, f: 2.2, b: false)
-      check a[2] == MyObject(i: 11, f: 2.2, b: false)
+    p[1].f = 123.456
+    check a[1].f == 123.456
+    p[2] = MyObject(i: 11, f: 2.2, b: false)
+    check a[2] == MyObject(i: 11, f: 2.2, b: false)
 
   test "inplace incr ptr":
-    ptrMath:
-      p += 2
-      check p[0].i == 500
-      p[0].f = 7.89
-      check a[2].f == 7.89
+    p += 2
+    check p[0].i == 500
+    p[0].f = 7.89
+    check a[2].f == 7.89
 
   test "inplace decr ptr":
-    ptrMath:
-      p = addr(a[2])
-      p -= 1
-      check p[-1].i == 100
-      p[1].f = 456.789
-      check a[2] == MyObject(i: 500, f: 456.789, b: true)
+    p = addr(a[2])
+    p -= 1
+    check p[-1].i == 100
+    p[1].f = 456.789
+    check a[2] == MyObject(i: 500, f: 456.789, b: true)


### PR DESCRIPTION
Fixes https://github.com/kaushalmodi/ptr_math/issues/1

This simplifies the usage of this module and also the doc generation.

1. Now the user does not need to worry about using the (old)
   `ptrMath:` twice or more in the same scope.
2. No need for `ptrMath:` block in the code; just `import ptr_math`
   will suffice.
3. doc gen is a lot simpler -- No need to use --docInternal.

/cc @timotheecour Can you please review this PR? It will be best view in Split view: https://github.com/kaushalmodi/ptr_math/pull/2/files?diff=split&w=1